### PR TITLE
Add GitHub repository governance configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS
+#
+# This file defines code ownership for the FSI Agent Kit repository.
+# GitHub automatically requests reviews from code owners when PRs affect their files.
+#
+# Syntax: <file-pattern> <owner(s)>
+# @vivibui is the primary owner and must approve all changes
+
+# Default: All files require approval from @vivibui
+* @vivibui
+
+# Critical directories - require explicit approval
+/.github/ @vivibui
+/platform/ @vivibui
+/applications/ @vivibui
+/strategy @vivibui
+
+# Infrastructure code - requires approval
+*.tf @vivibui
+*.tfvars @vivibui
+/infrastructure/ @vivibui
+
+# CI/CD pipelines - requires approval
+/.github/workflows/ @vivibui
+.gitlab-ci.yml @vivibui
+
+# Documentation - requires approval
+README.md @vivibui
+/docs/ @vivibui
+
+# Security and compliance
+SECURITY.md @vivibui
+LICENSE @vivibui

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,192 @@
+# Contributing to FSI Agent Kit
+
+Thank you for your interest in contributing to the FSI Agent Kit!
+
+## Repository Access
+
+**🌟 This is a public open-source repository - contributions are welcome!**
+
+- **Anyone can contribute** by forking and creating pull requests
+- All contributions must be **reviewed and approved** before merge
+- Follow the guidelines below to ensure smooth collaboration
+
+## Contribution Process
+
+### 1. Before You Start
+
+- Review existing issues and PRs to avoid duplicates
+- For major changes, open an issue first to discuss with @vivibui
+- Read the documentation to understand the project structure
+
+### 2. Making Changes
+
+**Fork and Branch:**
+```bash
+# 1. Fork the repository on GitHub (click "Fork" button)
+
+# 2. Clone YOUR fork
+git clone https://github.com/YOUR_USERNAME/sample-aws-fsi-agent-kit.git
+cd sample-aws-fsi-agent-kit
+
+# 3. Add upstream remote to stay in sync
+git remote add upstream https://github.com/aws-samples/sample-aws-fsi-agent-kit.git
+
+# 4. Create a feature branch
+git checkout -b feature/my-feature-name
+
+# 5. Keep your fork updated
+git fetch upstream
+git rebase upstream/main
+```
+
+**Make Your Changes:**
+- Follow the existing code style and conventions
+- Write clear, descriptive commit messages
+- Add tests for new functionality
+- Update documentation as needed
+
+**Test Your Changes:**
+```bash
+# Run tests locally
+pytest tests/
+
+# Test deployment (if applicable)
+# (follow instructions in relevant README)
+```
+
+### 3. Submitting a Pull Request
+
+```bash
+# 1. Commit your changes
+git add .
+git commit -m "feat: add new feature description"
+
+# 2. Push to YOUR fork
+git push origin feature/my-feature-name
+```
+
+**On GitHub:**
+1. Go to **your fork** on GitHub
+2. Click "Compare & pull request" (or "New Pull Request")
+3. **Base repository**: `aws-samples/sample-aws-fsi-agent-kit` base: `main`
+4. **Head repository**: `YOUR_USERNAME/sample-aws-fsi-agent-kit` compare: `feature/my-feature-name`
+5. Fill out the PR template completely
+6. Click "Create Pull Request"
+
+### 4. Code Review Process
+
+**Required Approval:**
+- **ALL pull requests require approval from @vivibui**
+- No direct pushes to `main` branch are allowed
+- No CI/CD checks required (manual review only)
+
+**Review Timeline:**
+- Initial review typically within 2-3 business days
+- Feedback will be provided via PR comments
+- Address feedback and push updates to your branch
+
+**Merging:**
+- PRs are merged by @vivibui only
+- Squash and merge is preferred to keep history clean
+- After merge, your branch will be automatically deleted
+
+## Branch Protection Rules
+
+The `main` branch is protected with the following rules:
+
+- ✅ Require pull request before merging
+- ✅ Require 1 approval from @vivibui
+- ✅ Dismiss stale reviews when new commits are pushed
+- ✅ Require status checks to pass before merge
+- ✅ Require conversation resolution before merge
+- ❌ No direct pushes to `main` (including admins)
+- ✅ Require linear history (squash merge)
+
+## Code Style Guidelines
+
+### Python
+- Follow PEP 8
+- [Optional] Use `black` for formatting
+- [Optional] Use `flake8` for linting
+- Type hints preferred for public APIs
+
+### Terraform
+- Follow HashiCorp style guide
+- [Optional] Use `terraform fmt`
+- Include variable descriptions
+- Document module usage in README
+
+### Documentation
+- Use clear, concise language
+- Include examples where applicable
+- Update README files when adding features
+- Keep documentation in sync with code
+
+## Testing Requirements
+
+All contributions must include appropriate tests:
+
+- **Unit Tests**: For individual functions and classes
+- **Integration Tests**: For component interactions
+- **Property-Based Tests**: For complex logic (where applicable)
+- **Documentation**: For public APIs
+
+## Commit Message Format
+
+Use conventional commits format:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Code style changes (formatting)
+- `refactor`: Code refactoring
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks
+
+**Examples:**
+```
+feat(control-plane): add template composition engine
+
+Implements Phase 5 composition system to replace pre-built templates
+with modular components. Reduces template count from 36 to 12.
+
+Closes #123
+```
+
+## Getting Help
+
+- **For bugs**: Open an issue with reproduction steps
+- **For feature requests**: Open an issue to discuss with @vivibui
+- **For questions**: Open a GitHub Discussion
+- **For security issues**: See [SECURITY.md](../SECURITY.md)
+
+## Recognition
+
+Contributors will be recognized in:
+- GitHub contributors page
+- Release notes (for significant contributions)
+- CONTRIBUTORS.md file
+
+## Code of Conduct
+
+- Be respectful and professional
+- Focus on constructive feedback
+- Help others learn and grow
+- Follow GitHub Community Guidelines
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache 2.0 License.
+
+---
+
+Thank you for contributing to FSI Agent Kit! 🚀

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Report a bug or issue
+title: '[BUG] '
+labels: bug
+assignees: vivibui
+
+---
+
+## Bug Description
+
+<!-- A clear and concise description of the bug -->
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen -->
+
+## Actual Behavior
+
+<!-- What actually happened -->
+
+## Environment
+
+- OS: [e.g., macOS, Ubuntu 22.04]
+- Python version: [e.g., 3.11.5]
+- Terraform version: [e.g., 1.6.0]
+- AWS Region: [e.g., us-east-1]
+- Deployment Pattern: [e.g., AgentCore, EC2, Step Functions]
+- Framework: [e.g., LangGraph, Strands]
+
+## Logs/Screenshots
+
+<!-- Add any relevant logs or screenshots -->
+
+```
+Paste logs here
+```
+
+## Additional Context
+
+<!-- Any other context about the problem -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,47 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[FEATURE] '
+labels: enhancement
+assignees: vivibui
+
+---
+
+## Feature Description
+
+<!-- Clear description of the feature you'd like -->
+
+## Use Case
+
+<!-- Describe the problem this feature would solve -->
+
+## Proposed Solution
+
+<!-- Describe how you'd like this to work -->
+
+## Alternatives Considered
+
+<!-- Describe any alternative solutions you've considered -->
+
+## Implementation Complexity
+
+- [ ] Low - Simple addition
+- [ ] Medium - Moderate changes required
+- [ ] High - Significant architecture changes
+
+## Related Phase
+
+<!-- Which Control Plane phase does this relate to? -->
+- [ ] Phase 1 - Foundation
+- [ ] Phase 2 - IaC Variety
+- [ ] Phase 3 - Tools & MCP
+- [ ] Phase 4 - Multi-Pattern
+- [ ] Phase 5 - Composition
+- [ ] Phase 6 - Advanced Config
+- [ ] Phase 7 - Marketplace
+- [ ] Phase 8 - Enterprise
+- [ ] Other
+
+## Additional Context
+
+<!-- Any other context, mockups, or examples -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+## Description
+
+<!-- Provide a clear description of what this PR does -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Infrastructure change
+- [ ] Refactoring (no functional changes)
+
+## Related Issue/Spec
+
+<!-- Link to the issue or spec this PR addresses -->
+- Issue: #
+- Spec: `link/to/spec`
+
+## Changes Made
+
+<!-- List the specific changes made in this PR -->
+-
+-
+-
+
+## Testing
+
+<!-- Describe the testing you've done -->
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing completed
+- [ ] All tests passing
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code where necessary
+- [ ] I have updated documentation as needed
+- [ ] I have tested my changes locally
+- [ ] New and existing tests pass locally with my changes (if applicable)
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots for UI changes -->
+
+## Additional Notes
+
+<!-- Any additional information reviewers should know -->
+
+---
+
+**Note**: This PR requires approval from @vivibui before merge.


### PR DESCRIPTION
## Summary

Add contribution configuration to establish governance rules for the public open-source repository.

## Changes Made

- **PR Template** (`.github/pull_request_template.md`): Standardized checklist for contributors
- **Issue Templates**: Bug report and feature request templates
- **Contributing Guide** (`.github/CONTRIBUTING.md`): Fork-based workflow for public contributions

## Effect

Once merged, these files will:
1. ✅ Provide templates for contributors when creating PRs and issues
2. ✅ Document the contribution workflow for external contributors
3. ✅ Work with the branch protection rules already configured on GitHub

## Test Plan

- [x] All documentation references updated
- [x] Commit message follows conventional format
- [x] No sensitive files included