### PR TITLE
fix(deploy): Identity Center role path + optional hosted zone

### DIFF
--- a/platform/control_plane/infrastructure/scripts/acm.sh
+++ b/platform/control_plane/infrastructure/scripts/acm.sh
@@ -56,7 +56,15 @@ API_ACM_CERTIFICATE_ARN=$(terraform output -raw api_acm_certificate_arn)
 # from the caller identity into TF_VAR_lf_admin_role_arn; replicate that here
 # so the second apply doesn't fail on module.sample_datalake.
 CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
-export TF_VAR_lf_admin_role_arn=$(echo "$CALLER_ARN" | sed 's|arn:aws:sts::\([0-9]*\):assumed-role/\([^/]*\)/.*|arn:aws:iam::\1:role/\2|')
+LF_ADMIN_ROLE_ARN=$(echo "$CALLER_ARN" | sed 's|arn:aws:sts::\([0-9]*\):assumed-role/\([^/]*\)/.*|arn:aws:iam::\1:role/\2|')
+# Resolve the path-qualified ARN (IAM Identity Center roles sit under
+# /aws-reserved/sso.amazonaws.com/ and Lake Formation rejects path-less ARNs).
+LF_ROLE_NAME=$(echo "$LF_ADMIN_ROLE_ARN" | sed 's|.*:role/||')
+LF_RESOLVED_ARN=$(aws iam get-role --role-name "$LF_ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || echo "")
+if [ -n "$LF_RESOLVED_ARN" ] && [ "$LF_RESOLVED_ARN" != "None" ]; then
+    LF_ADMIN_ROLE_ARN="$LF_RESOLVED_ARN"
+fi
+export TF_VAR_lf_admin_role_arn="$LF_ADMIN_ROLE_ARN"
 
 echo "[B] CP terraform re-apply"
 cd "$INFRA_DIR"

--- a/platform/control_plane/infrastructure/scripts/deploy-full.sh
+++ b/platform/control_plane/infrastructure/scripts/deploy-full.sh
@@ -121,6 +121,15 @@ terraform init -input=false
 # Extract IAM role ARN from current credentials for Lake Formation admin
 CALLER_ARN=$(aws sts get-caller-identity --query Arn --output text)
 LF_ADMIN_ROLE_ARN=$(echo "$CALLER_ARN" | sed 's|arn:aws:sts::\([0-9]*\):assumed-role/\([^/]*\)/.*|arn:aws:iam::\1:role/\2|')
+# The sed above drops the role's IAM path. IAM Identity Center (SSO) roles live
+# under /aws-reserved/sso.amazonaws.com/, and Lake Formation's PutDataLakeSettings
+# rejects a path-less ARN with "InvalidInputException: Invalid path for user".
+# Resolve the authoritative, path-qualified ARN via iam:GetRole when possible.
+LF_ROLE_NAME=$(echo "$LF_ADMIN_ROLE_ARN" | sed 's|.*:role/||')
+LF_RESOLVED_ARN=$(aws iam get-role --role-name "$LF_ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || echo "")
+if [ -n "$LF_RESOLVED_ARN" ] && [ "$LF_RESOLVED_ARN" != "None" ]; then
+    LF_ADMIN_ROLE_ARN="$LF_RESOLVED_ARN"
+fi
 export TF_VAR_lf_admin_role_arn="$LF_ADMIN_ROLE_ARN"
 echo -e "${GREEN}Lake Formation admin role: ${LF_ADMIN_ROLE_ARN}${NC}"
 # Pre-import X-Ray Transaction Search prereqs that are account+region-scoped
@@ -207,10 +216,28 @@ if [ -z "${HOSTED_ZONE_DOMAIN:-}" ] && [ -f "$REPO_ROOT/.env" ]; then
 fi
 
 HZ_DIR="$INFRA_DIR/bootstrap/hosted_zone"
-HZ_DOMAIN="${HOSTED_ZONE_DOMAIN:?HOSTED_ZONE_DOMAIN not set. Add it to .env or export it before running deploy-full.sh.}"
+# HOSTED_ZONE_DOMAIN is only required when we are actually creating the zone.
+# Accounts without a delegable public domain (sandboxes, workshop accounts)
+# set DEPLOY_HOSTED_ZONE=false and stay on the default *.cloudfront.net URL,
+# so do NOT hard-fail on an unset variable here.
+HZ_DOMAIN="${HOSTED_ZONE_DOMAIN:-}"
 HZ_ID=""
 
-if [ "${DEPLOY_HOSTED_ZONE:-true}" = "true" ] && [ -d "$HZ_DIR" ]; then
+if [ "${DEPLOY_HOSTED_ZONE:-true}" != "true" ]; then
+    echo -e "${YELLOW}[1b/9] Skipped: DEPLOY_HOSTED_ZONE=false.${NC}"
+    echo    "  No Route 53 hosted zone created. The Control Plane will be served on its"
+    echo    "  default CloudFront and API Gateway domain names."
+    echo
+elif [ ! -d "$HZ_DIR" ]; then
+    echo -e "${YELLOW}[1b/9] Skipped: $HZ_DIR not present.${NC}"
+    echo
+elif [ -z "$HZ_DOMAIN" ]; then
+    echo -e "${RED}Error: HOSTED_ZONE_DOMAIN is not set.${NC}"
+    echo "  Either set HOSTED_ZONE_DOMAIN in $REPO_ROOT/.env (a subdomain of a public"
+    echo "  zone you control), or skip the custom-domain path entirely with:"
+    echo "      DEPLOY_HOSTED_ZONE=false ./deploy-full.sh"
+    exit 1
+else
     echo -e "${BLUE}[1b/9] Route 53 hosted zone bootstrap${NC}"
 
     pushd "$HZ_DIR" > /dev/null
@@ -227,11 +254,8 @@ if [ "${DEPLOY_HOSTED_ZONE:-true}" = "true" ] && [ -d "$HZ_DIR" ]; then
     popd > /dev/null
 
     echo -e "${GREEN}  Hosted zone ${HZ_DOMAIN} ready (id=${HZ_ID}).${NC}"
-    echo -e "${YELLOW}  Send these NS records to the parent-zone (example.com) owner:${NC}"
+    echo -e "${YELLOW}  Send these NS records to the parent-zone owner:${NC}"
     echo "$HZ_NAMESERVERS" | python3 -c "import sys,json;[print(f'    {n}') for n in json.load(sys.stdin)]" 2>/dev/null || echo "  (name_servers output unavailable)"
-    echo
-elif [ ! -d "$HZ_DIR" ]; then
-    echo -e "${YELLOW}[1b/9] Skipped: $HZ_DIR not present.${NC}"
     echo
 fi
 
@@ -300,8 +324,9 @@ echo
 echo -e "${BLUE}[3/7] Service-Approval runner image${NC}"
 
 if [ -z "$RUNNER_ECR_REPO" ]; then
-    echo -e "${YELLOW}  service_approval_runner_ecr_repository_url not in tf outputs — skipping.${NC}"
-    echo -e "${YELLOW}  (Service Onboarding pipeline will fail until the image is pushed.)${NC}"
+    echo -e "${GREEN}  Not required: the Fargate service-approval runner was decommissioned${NC}"
+    echo -e "${GREEN}  (Phase B). Service Onboarding now runs on an AgentCore runtime, so there${NC}"
+    echo -e "${GREEN}  is no runner image to build. Skipping.${NC}"
 elif [ ! -f "$RUNNER_DIR/Dockerfile" ]; then
     echo -e "${YELLOW}  Runner source not found at $RUNNER_DIR — skipping.${NC}"
 else


### PR DESCRIPTION
## Description

Fixes two blockers in the Control Plane deployment scripts that prevent `deploy-full.sh` from
completing on common customer account setups, plus one misleading log message.

Both blockers fail **mid-deployment** — after `terraform apply` has already created resources — so
the failure mode is a partially-provisioned account rather than a clean early exit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure change
- [ ] Refactoring (no functional changes)

## Related Issue/Spec

- Issue: #125
- Spec: n/a — found during a full end-to-end production deployment

Closes #125

## Changes Made

### 1. Lake Formation admin ARN drops the IAM role path (blocking, IAM Identity Center)

`deploy-full.sh` and `acm.sh` both reconstruct the Lake Formation admin ARN from
`sts:GetCallerIdentity` with a `sed` expression:

```bash
LF_ADMIN_ROLE_ARN=$(echo "$CALLER_ARN" | sed 's|arn:aws:sts::\([0-9]*\):assumed-role/\([^/]*\)/.*|arn:aws:iam::\1:role/\2|')
```

That assumes the role sits at the IAM root path. IAM Identity Center roles do not — they live under
`/aws-reserved/sso.amazonaws.com/`. Lake Formation validates the path and rejects the flattened form:

```
Error: creating Lake Formation data lake settings: operation error LakeFormation:
PutDataLakeSettings, https response error StatusCode: 400,
InvalidInputException: Invalid path for user,
arn: arn:aws:iam::<account>:role/AWSReservedSSO_AdministratorAccess_<suffix>
```

This affects **any account using Identity Center** with the default `enable_sample_datalake = true`,
and the apply dies roughly 50 resources in. The bug is invisible on plain IAM roles and IAM users,
which is why it survives testing.

Both scripts now resolve the authoritative, path-qualified ARN via `iam:GetRole`, falling back to the
previous behaviour if the lookup fails — so plain IAM roles and users are unaffected.

### 2. `DEPLOY_HOSTED_ZONE=false` does not actually skip the hosted zone (blocking, sandbox accounts)

The documented way to skip the custom-domain path is `DEPLOY_HOSTED_ZONE=false`, but the
error-if-unset expansion is evaluated *before* the flag is tested:

```bash
HZ_DOMAIN="${HOSTED_ZONE_DOMAIN:?HOSTED_ZONE_DOMAIN not set. ...}"   # always runs
if [ "${DEPLOY_HOSTED_ZONE:-true}" = "true" ] && [ -d "$HZ_DIR" ]; then
```

So `HOSTED_ZONE_DOMAIN` is mandatory even when you have explicitly asked not to create a zone — and
because this sits after step 1, the script aborts *between phases*, with infrastructure already
applied.

This blocks accounts with no delegable public domain: Innovation Sandbox, workshop, and demo
accounts. Those deployments are otherwise perfectly viable, since every custom-domain resource in the
`cloudfront` and `api_gateway` modules is already gated on
`domain_name != "" && hosted_zone_id != "" && acm_certificate_arn != ""`.

The variable is now optional, and required only on the branch that actually creates the zone. The
`if/elif` chain covers all four combinations:

| `DEPLOY_HOSTED_ZONE` | `HOSTED_ZONE_DOMAIN` | Behaviour |
|---|---|---|
| `false` | unset | Skip — stays on default CloudFront / API Gateway domains |
| `false` | set | Skip |
| `true` (default) | unset | Clear error naming both remedies |
| `true` (default) | set | Create the zone, print the 4 NS records |

### 3. Phase 3 prints a false failure warning (cosmetic)

Phase 3 currently prints:

```
service_approval_runner_ecr_repository_url not in tf outputs — skipping.
(Service Onboarding pipeline will fail until the image is pushed.)
```

This is stale. The Fargate service-approval runner ECR was removed deliberately in Phase B — see the
comment in `infrastructure/outputs.tf`:

```
# Phase B decommission: service_approval_runner_ecr_repository_url removed.
# The Fargate runner ECR no longer exists — the v2 module owns the AgentCore ...
```

Service Onboarding now runs on an AgentCore runtime, so nothing is broken and no image is needed. The
message tells customers a feature is broken when it is not. Replaced with an accurate note.

Also removed a hardcoded `example.com` reference from the NS-records prompt.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

Validated by a full end-to-end deployment of the Control Plane in production mode with every optional
component enabled (`us-east-1`, IAM Identity Center credentials, `environment = "prod"`):

- Reproduced the Lake Formation failure on the unpatched scripts, then confirmed a clean
  `Apply complete! Resources: 50 added, 1 changed, 1 destroyed` after the fix, with the ARN resolving
  to the path-qualified `/aws-reserved/sso.amazonaws.com/` form.
- Post-deploy verification: ECS 2/2 tasks healthy with `rolloutState: COMPLETED`, ALB targets
  healthy, frontend HTTP 200, API `/health` reporting `database: connected` and `s3: accessible`.
- Exercised all four branches of the new hosted-zone logic in isolation and confirmed each takes the
  intended path.
- Both scripts pass `bash -n`.
- Also completed on the same stack, exercising the touched code paths: CodeCommit seeding (42 repos),
  Docker Hub auth, and the full `acm.sh` custom-domain flow (2 ACM certs issued, CloudFront and API
  Gateway custom domains live).

No automated test suite covers these scripts, hence manual validation only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated documentation as needed
- [x] I have tested my changes locally
- [x] New and existing tests pass locally with my changes (if applicable)

Documentation is unchanged: fix 1 is transparent to users, and fix 2 makes the **already-documented**
`DEPLOY_HOSTED_ZONE=false` behaviour work as described in `scripts/README.md`. Happy to add a note to
that README about the no-DNS deployment path if reviewers would like it in the same PR.

## Additional Notes

Two further issues encountered during the same deployment are **environment**, not code, so they are
not addressed here. Flagging them in case they are worth separate issues:

1. **AWS CLI ≥ 2.36 is a hard prerequisite.** `modules/agent_registry` shells out to
   `aws agent-registry-control`, which does not exist in earlier CLI versions. The module already
   fails loudly with a good message; it may be worth stating the minimum version in the deployment
   docs alongside the Terraform and Node requirements.
2. **`seed-codecommit.sh` has two portability problems.** Its `pip3 install boto3` fails under
   PEP 668 on macOS/Homebrew and most current Linux distros, and the CodeCommit HTTPS credential
   helper returns `403` with long IAM Identity Center session tokens (it failed for me after 19 of 42
   repos). Working around the latter needs `git-remote-codecommit` and `codecommit::` remote URLs.
   Fixing the git transport is a larger change than belongs in this PR.
