### PR TITLE
fix(deploy): non-reserved placeholder domain in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,6 @@ DEPLOYMENT_MODE=fastapi
 # provisions ACM certs for <HOSTED_ZONE_DOMAIN> and api.<HOSTED_ZONE_DOMAIN>
 # and wires them into CloudFront + API Gateway. Change this if you want a
 # different DNS name.
-HOSTED_ZONE_DOMAIN=ava-demo.example.com
-API_DOMAIN=api.ava-demo.example.com
+HOSTED_ZONE_DOMAIN=ava-demo.example123.com
+API_DOMAIN=api.ava-demo.example123.com
 API_PREFIX=api


### PR DESCRIPTION
example.com is IANA-reserved (RFC 2606); Route 53 rejects it with InvalidDomainName. Replace with a fill-in placeholder so hosted-zone creation works.